### PR TITLE
Use registerTwigExtension()

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -25,7 +25,7 @@ class Plugin extends \craft\base\Plugin
     {
         parent::init();
                 
-        \Craft::$app->view->twig->addExtension(new CloudinaryTwigExtension());
+        \Craft::$app->view->registerTwigExtension(new CloudinaryTwigExtension());
         
         \Cloudinary::config(array(
             "cloud_name" => $this->settings->cloudName, 


### PR DESCRIPTION
Fixes a bug where the plugin may cause Twig to be loaded before it should be, and another bug where the extension might not be available if the Template Mode ever changes from CP to Site, or vise-versa.